### PR TITLE
fix allowed hosts array in settings.py

### DIFF
--- a/template/core/settings.py
+++ b/template/core/settings.py
@@ -33,7 +33,7 @@ DEBUG = str2bool(os.environ.get('DEBUG'))
 #print(' DEBUG -> ' + str(DEBUG) ) 
 
 # Docker HOSTs
-ALLOWED_HOSTS = ['nwapinball.com', 'localhost', '127.0.0.1', 'https://repo-799203625865.us-central1.run.app/' 'https://repo-i44nxp2gja-uc.a.run.app/']
+ALLOWED_HOSTS = ['nwapinball.com', 'localhost', '127.0.0.1', 'https://repo-799203625865.us-central1.run.app/', 'https://repo-i44nxp2gja-uc.a.run.app/']
 
 PORT = os.getenv('PORT', '8080')
 


### PR DESCRIPTION
I was missing a comma for the allowed hosts array in settings.py